### PR TITLE
fixed sprite transfer and some sequences of operation

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -6,6 +6,7 @@
 typedef struct
 {
 	uint8_t disable;
+	uint8_t reset_dma;
 	uint8_t wr0;
 	void *source;
 	uint16_t length;
@@ -62,6 +63,7 @@ typedef struct
 dma_code_t dma_code_transfer =
 {
 	.disable = D_DISABLE_DMA,
+	.reset_dma = 0xc3,											// r6-reset dma
 	.wr0 = D_WR0 | D_WR0_X56_LEN | D_WR0_X34_A_START | D_WR0_TRANSFER_A_TO_B,
 	.source = 0,
 	.length = 0,
@@ -79,6 +81,7 @@ dma_code_t dma_code_transfer =
 dma_code_t dma_code_transfer_reversed =
 {
 	.disable = D_DISABLE_DMA,
+	.reset_dma = 0xc3,											// r6-reset dma
 	.wr0 = D_WR0 | D_WR0_X56_LEN | D_WR0_X34_A_START | D_WR0_TRANSFER_A_TO_B,
 	.source = 0,
 	.length = 0,
@@ -96,6 +99,7 @@ dma_code_t dma_code_transfer_reversed =
 dma_code_t dma_code_transfer_io =
 {
 	.disable = D_DISABLE_DMA,
+	.reset_dma = 0xc3,											// r6-reset dma
 	.wr0 = D_WR0 | D_WR0_X56_LEN | D_WR0_X34_A_START | D_WR0_TRANSFER_A_TO_B,
 	.source = 0,
 	.length = 0,
@@ -127,7 +131,7 @@ dma_code_fill_t dma_code_fill =
 
 dma_code_sample_t dma_code_sample_io =
 {
-	.disable_dma = D_DISABLE_DMA,								// r6-disable dm
+	.disable_dma = D_DISABLE_DMA,								// r6-disable dma
 	.reset_dma = 0xc3,											// r6-reset dma
 	.reset_port_a = 0xc7,										// r6-reset port a timing
 	.timing_a_b = 0xcb,											// r6-reset port b timing
@@ -180,7 +184,7 @@ void dma_transfer_sprite(void *source, uint16_t length)
 {
 	dma_code_transfer_io.source = source;
 	dma_code_transfer_io.length = length;
-	dma_code_transfer_io.dest = (void *)IO_SPRITE_PATTERN;
+	dma_code_transfer_io.dest = (void*)IO_SPRITE_PATTERN_DEST;
 	
 	z80_otir(&dma_code_transfer_io, IO_DMA_PORT, sizeof(dma_code_transfer_io));
 }

--- a/src/dma.h
+++ b/src/dma.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 #define IO_DMA_PORT             0x6B
+#define IO_SPRITE_PATTERN_DEST  0x005B
 #define SAMPLE_COVOXPORT        0xffdf
 #define SAMPLE_LOOP             D_WR5 | D_WR5_RESTART | D_WR5_CE_WAIT
 #define SAMPLE_NOLOOP           D_WR5


### PR DESCRIPTION
the sprite transfer function (dma_transfer_sprite) didn't work. I examined the generated code (.lis) and changed IO_SPRITE_PATTERN to a custom #defined value (IO_SPRITE_PATTERN_DEST).

also, if a sequence like this is performed:
- transfer a sprite set (spriteset 1)
- play an audio sample
- transfer a sprite set (spriteset 2)

without these corrections (reset_dma), the second sprite transfer is very slow on real machine, and sprites become corrupt on CSpect.

it is a complicated case, as it involucrates two completely different features such as sprites and sound samples, but as both of them use DMA, they are related - the reset_dma seems to fix the sequence failure.

unfortunately the test case for the sequence situation is complicated, it is a work-in-progress and I cannot publish it.

as this demo is centered in sound sample transfer, feel free to not accept this pull request.